### PR TITLE
fixes #1 by changing createrRenderer function

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class ElectronVue extends Vue {
             // if there's not already a render method then generate one from
             // the template attribute
             if(!args[0].render)
-                args[0].render = ElectronVue.createRenderer(args[0].template);
+                args[0] = Object.assign(args[0], ElectronVue.createRenderer(args[0].template));
 
             // register local components which just means to convert component
             // template attributes to render functions
@@ -52,7 +52,7 @@ class ElectronVue extends Vue {
             // if there's not a render method then generate one from the
             // template attribute
             if(!component.render)
-                component.render = ElectronVue.createRenderer(component.template);
+                component.render = ElectronVue.createRenderer(component.template).render;
 
             // if this component has child components then recursively
             // register them too
@@ -77,7 +77,7 @@ class ElectronVue extends Vue {
             }
         }
 
-        return compiler.compileToFunctions(template).render;
+        return compiler.compileToFunctions(template);
     }
 
     /**


### PR DESCRIPTION
I gave this one a spin.  Unit tests are passing but the problem is they already were.  I setup a super simple test using the following:

**client.js**
```JavaScript
const {ipcRenderer} = require('electron');
const ElectronVue = require('@nullkeys/electron-vue');

new ElectronVue({
    el: '#app',
    template: '<div><div>{{ message }}</div></div>',
    data: {
        message: 'GET TO THE CHOPPAH!'
    }
});
```

**test.html**
```html
<div id="app"></div>
<div>Testing the testy test</div>

<script src="./client.js"></script>
```

You probably have something already setup that can easily reproduce the issue so let me know if I'm completely off base here.